### PR TITLE
Fix inline-js CRLF issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ cache:
   directories:
     - "node_modules"
 
-before_install:
-  - npm install --global npm@"^5.4.0"
-
 branches:
   only:
     - master

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "indent-string": "^3.2.0",
-    "inline-js": "^0.3.0"
+    "inline-js": "^0.3.1"
   },
   "private": true
 }


### PR DESCRIPTION
By upgrading `inline-js@^0.3.1` that fix the `CRLF` issue, we don't need latest npm when building.

