### PR TITLE
Fix Wikipedia block position

### DIFF
--- a/src/inject.css
+++ b/src/inject.css
@@ -216,11 +216,14 @@
 
 /**
  * Move Wikipedia block to the right.
- * (Use transform because the block already has margin.)
  */
 
-#cnt:not(.rfli) #rhs {
-  transform: translateX(var(--user-sidebar-spacer)) !important;
+#cnt:not(.rfli) #rhscol {
+  margin-left: var(--user-sidebar-width) !important;
+}
+
+#cnt:not(.rfli) #rhs_block {
+  margin-left: calc(-1 * (var(--user-sidebar-width) / 2)) !important;
 }
 
 /* Top Search Form


### PR DESCRIPTION
Adapted some CSS from [Google Search Tools Back](https://userstyles.org/styles/95110/google-search-tools-back) and fixed the Wikipedia block position. However, if the sidebar width is larger than about 400px, the main content still overlaps to the Wikipedia block. Thus,  the recommended sidebar width is 150px ~ 350px.