### PR TITLE
Make the userscript run after the page is loaded

### DIFF
--- a/src/user.js
+++ b/src/user.js
@@ -12,7 +12,7 @@
 // @compatible      firefox
 // @compatible      chrome
 // @compatible      opera
-// @run-at          document-start
+// @run-at          document-end
 // @grant           none
 // ==/UserScript==
 
@@ -20,7 +20,7 @@ function GM_addStyle (css) {
   const style = document.createElement('style')
   style.type = 'text/css'
   style.textContent = css
-  document.documentElement.appendChild(style)
+  document.head.appendChild(style)
   return style
 }
 


### PR DESCRIPTION
When the browser opens the search page in the background, another inline `<style>` will be inserted to the <head> and overrides our sidebar CSS.

This commit makes sure that the sidebar CSS is correctly inserted to the `<head>`.

(Fix issue #36).
