### PR TITLE
Update metadata block

### DIFF
--- a/src/user.css
+++ b/src/user.css
@@ -12,6 +12,6 @@
 @namespace url(http://www.w3.org/1999/xhtml);
 
 @-moz-document
-  regexp("^https?:\/\/www\.google\.(?:[A-z\.]+)(?:\:\d)?\/(?:(search|webhp))\?.+") {
+  regexp("^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?!(?:.+&)?tbm=lcl(?:&.+)?).+$") {
   /* $inline.line('inject.css|indent:2|trim') */
 }

--- a/src/user.js
+++ b/src/user.js
@@ -5,7 +5,7 @@
 // @description     $inline('pkg:description')
 // @author          $inline('pkg:author,name')
 // @license         $inline('pkg:license')
-// @homepage        $inline('pkg:homepage')
+// @homepageURL     $inline('pkg:homepage')
 // @supportURL      $inline('pkg:bugs,url')
 // @include         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?q=[^&]+(?:&.+)?$/
 // @exclude         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?tbm=lcl(?:&.+)?$/

--- a/src/user.js
+++ b/src/user.js
@@ -7,8 +7,8 @@
 // @license         $inline('pkg:license')
 // @homepage        $inline('pkg:homepage')
 // @supportURL      $inline('pkg:bugs,url')
-// @include         https://www.google.*/search?*
-// @include         https://www.google.*/webhp?*
+// @include         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?q=[^&]+(?:&.+)?$/
+// @exclude         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?tbm=lcl(?:&.+)?$/
 // @compatible      firefox
 // @compatible      chrome
 // @compatible      opera

--- a/src/user.js
+++ b/src/user.js
@@ -11,6 +11,7 @@
 // @exclude         /^https:\/\/(?:ipv4|ipv6|www)\.google\.(?:[a-z\.]+)\/search\?(?:.+&)?tbm=lcl(?:&.+)?$/
 // @compatible      firefox
 // @compatible      chrome
+// @compatible      edge
 // @compatible      opera
 // @run-at          document-end
 // @grant           none


### PR DESCRIPTION
This pull request updates the metadata block of UserJS and UserCSS.

- [x] Remove old `www.google.*/webhp` URL. (0c8295e83cf4776c27c314f10dbfed0616611664)
- [x] Support `ipv4.google.com` and `ipv6.google.com` domains. (0c8295e83cf4776c27c314f10dbfed0616611664)
- [x] Exclude location search page. (Fix #45) (0c8295e83cf4776c27c314f10dbfed0616611664)
- [x] Change `@homepage` to `@homepageURL` because Greasemonkey only accepts the later. (4dbf248d04ba8b6915947e065cf3b6a6c6247239)
- [x] Flag the UserJS as compatible with Microsoft Edge on Greasy Fork. (cea555d47b4a01750a3ead96cfb2d3183c9f76b2)
